### PR TITLE
Adding graph reloading

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -10,7 +10,9 @@ export class Graph extends React.Component {
     this.state = {
       link: null,
       node: null,
-      simulation: null
+      simulation: null,
+      svg: null,
+      g: null
     };
 
     this.generateGraph = this.generateGraph.bind(this);
@@ -20,11 +22,12 @@ export class Graph extends React.Component {
   }
 
   componentDidMount(){
+    this.prepareSvg();
     this.loadData(this.generateGraph);
   }
 
   onDateTimeSelect(){
-    this.loadData(this.graphUpdate)
+    this.loadData(this.graphUpdate);
   }
 
   loadData(cb) {
@@ -38,25 +41,34 @@ export class Graph extends React.Component {
   }
 
   graphUpdate(response){
-    /* 
-      Graph Update Code
-    */
+    this.state.g.selectAll('g').remove();
+    this.generateGraph(response);
   }
-
-  generateGraph(response) {
+  
+  prepareSvg(){
     const svg = d3.select('#chart-area')
       .append('svg')
       .style('width', '100%')
       .style('height', '100%');
-
-    const width = svg.node().getBoundingClientRect().width;
-    const height = svg.node().getBoundingClientRect().height;
 
     const g = svg
       .call(d3.zoom().on('zoom', () => {
         g.attr('transform', d3.event.transform);
       }))
       .append('g');
+
+    this.setState({
+      svg: svg,
+      g: g
+    });
+  }
+
+  generateGraph(response) {
+    const svg = this.state.svg;
+    const g = this.state.g;
+
+    const width = svg.node().getBoundingClientRect().width;
+    const height = svg.node().getBoundingClientRect().height;
 
     const links = response.data.links;
     const nodes = response.data.nodes;

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -10,9 +10,7 @@ export class Graph extends React.Component {
     this.state = {
       link: null,
       node: null,
-      simulation: null,
-      svg: null,
-      g: null
+      simulation: null
     };
 
     this.generateGraph = this.generateGraph.bind(this);
@@ -43,7 +41,7 @@ export class Graph extends React.Component {
   graphUpdate(response){
     this.generateGraph(response);
   }
-  
+
   prepareSvg(){
     const svg = d3.select('#chart-area')
       .append('svg')
@@ -79,8 +77,6 @@ export class Graph extends React.Component {
       .selectAll('circle');
 
     this.setState({
-      svg: svg,
-      g: g,
       link: link,
       node: node,
       simulation: simulation
@@ -100,7 +96,8 @@ export class Graph extends React.Component {
       .join(enter => enter.append('circle'))
       .attr('r', 10)
       .attr('fill', d => d.kind === 'pod' ? '#3f33ff' : null)
-      .attr('fill', d => d.kind === 'service' ? '#68686f' : null);
+      .attr('fill', d => d.kind === 'service' ? '#68686f' : null)
+      .call(this.drag(this.state.simulation));
 
     node.append('title')
       .text((d) => {return d.id;});


### PR DESCRIPTION
This PR intorduce graph reloading in OpenRCA UI. After user choose proper data, the request to MockAPI is processed and based on the data in response new graph is generated.

I manage to obtain solution, where there is calculating comparison between previous and next state (nodes, links etc.) during graph update. Only new objects are generated - rest of them is inherited from previous state. Thus in our case the animation will look very smooth  :sunglasses: 