### PR TITLE
Add scale graph feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-bootstrap": "^1.0.0",
     "react-datepicker": "^3.0.0",
     "react-dom": "^16.13.1",
+    "react-loader-spinner": "^3.1.14",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "react-select": "^3.1.0"

--- a/src/assets/ui.css
+++ b/src/assets/ui.css
@@ -9,3 +9,10 @@ html {
 .hidden {
     display:none;
 }
+
+.loader {
+    position: absolute;
+    width: 100%;
+    text-align: center;
+    margin-top: 20px;
+}

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as d3 from 'd3';
 import axios from 'axios';
+import Loader from 'react-loader-spinner'
 
 import { DateTimePicker } from './DateTimePicker';
 import { NodeDetailCard } from './NodeDetailCard';
@@ -18,7 +19,8 @@ export class Graph extends React.Component {
       namespace: null,
       data: null,
       svg: null,
-      g: null
+      g: null,
+      loading: true
     };
 
     this.zoom = d3.zoom();
@@ -30,9 +32,12 @@ export class Graph extends React.Component {
     this.nodeCircleRadius = 10;
     this.nodeDetailCard = React.createRef();
     this.scaleGraph = this.scaleGraph.bind(this);
+    this.graphLoad = this.graphLoad.bind(this);
   }
 
   componentDidMount() {
+    const div = document.getElementById('chart-area');
+    div.style.visibility = 'hidden';
     this.prepareSvg();
     this.loadData();
   }
@@ -129,8 +134,18 @@ export class Graph extends React.Component {
       svg: svg,
       g: g
     }, () => {
-      setTimeout(this.scaleGraph, 2000);
+      setTimeout(this.graphLoad, 2000);
     });
+  }
+
+  graphLoad() {
+    this.setState({
+      loading: false
+    }, () => {
+      const div = document.getElementById('chart-area');
+      div.style.visibility = 'visible';
+      this.scaleGraph();
+    })
   }
 
   scaleGraph(){
@@ -240,6 +255,9 @@ export class Graph extends React.Component {
   render() {
     return (
       <div>
+        <span className="loader">
+          <Loader type="TailSpin" visible={this.state.loading} color='#343a40'/>
+        </span>
         <div id="chart-area" />
         <NodeDetailCard ref={this.nodeDetailCard} />
         <DateTimePicker onSelect={this.onDateTimeSelect} options={this.state.options} handleNamespaceChange={this.handleNamespaceChange}/>

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as d3 from 'd3';
 import axios from 'axios';
-import Loader from 'react-loader-spinner'
+import Loader from 'react-loader-spinner';
 
 import { DateTimePicker } from './DateTimePicker';
 import { NodeDetailCard } from './NodeDetailCard';
@@ -145,7 +145,7 @@ export class Graph extends React.Component {
       const div = document.getElementById('chart-area');
       div.style.visibility = 'visible';
       this.scaleGraph();
-    })
+    });
   }
 
   scaleGraph(){

--- a/yarn.lock
+++ b/yarn.lock
@@ -9870,6 +9870,14 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-loader-spinner@^3.1.14:
+  version "3.1.14"
+  resolved "https://registry.yarnpkg.com/react-loader-spinner/-/react-loader-spinner-3.1.14.tgz#2a201f07379c492766175609903c0f2ced57c720"
+  integrity sha512-7V+upnW+RVA/O94LIB/EQLK2uaz/TpZBHG5uNXlOXgvxvALxlxVYeEDmus5Oex2C58fiwrsRvSyu/4VRmLbZ9Q==
+  dependencies:
+    babel-runtime "^6.26.0"
+    prop-types "^15.7.2"
+
 react-onclickoutside@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"


### PR DESCRIPTION
This PR is related to #22. Graph scaling and centering features were added.

The main difficulty is due to the fact that our graph is force directed tree. During simulation it dynamically changes shape, width and height. Scale and center operations base on this features. Thus it is hard to find the right moment for which these operations should trigger automatically. After tests in my environment I come to conclusion that proper value estimates about 2 seconds and I used it in this changes.

In my opinion it would be great to provide some button in UI which could trigger rescaling operation. User could easily adapt shape of his graph to available space.

I also think that initial seconds of operations could be hidden behind loader component. After some time (e.g. mentioned 2 seconds) automatic rescaling could be triggered and loader could be removed. This is strongly connected with #31 and should be considered in this task. So far we have ugly transition before initial state and rescaled one.

Despite mentioned inconveniences I personally think it will be great to introduce this changes first, because obtained behaviour is better than present one.

Automatic rescaled graph:
![iss22](https://user-images.githubusercontent.com/37223468/86230741-c94adc80-bb91-11ea-928a-b1450068432b.png)


Any feedback/ suggestions will be appreciated! :smile: 