### PR TITLE
Show only relevant information in card

### DIFF
--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -7,7 +7,10 @@ export class NodeDetailCard extends React.Component {
     super(props);
     this.state = {
       nodeData: {
-        kind: ''
+        kind: '',
+        properties: {
+          name: ''
+        }
       },
       hidden: true
     };
@@ -16,7 +19,7 @@ export class NodeDetailCard extends React.Component {
   }
 
   updateNodeData(nodeData) {
-    this.setState({nodeData: nodeData});
+    this.setState({ nodeData: nodeData });
   }
 
   hide() {
@@ -29,14 +32,19 @@ export class NodeDetailCard extends React.Component {
 
   render() {
     return (
-      <div className={`card node-info-card ${this.state.hidden ? 'hidden' : ''}`}>
-        <button type="button" className="close" aria-label="Close" onClick={this.hide}>
+      <div className={`card node-info-card ${this.state.hidden ? 'hidden' : ''} pt-0`}>
+        <button type="button" className="close mt-1 mr-2 mb-0" aria-label="Close" onClick={this.hide}>
           <span aria-hidden="true">&times;</span>
         </button>
-        <div className="card-body">
-          <h5 className="card-title">{this.state.nodeData.kind.replace('_', ' ')}</h5>
+        <div className="card-body mt-0 pt-0">
+          <h4 className="card-title">{this.state.nodeData.kind.replace('_', ' ')}</h4>
+          <h5 className="card-subtitle">{this.state.nodeData.properties.name}</h5>
           <div className="card-text node-info-text">
-            <pre>{JSON.stringify(this.state.nodeData, null, 2)}</pre>
+            <pre>{JSON.stringify(this.state.nodeData.properties, function (k, v) {
+              if (k !== 'name') {
+                return v;
+              }
+            }, 2)}</pre>
           </div>
         </div>
       </div>

--- a/src/components/NodeDetailCard.scss
+++ b/src/components/NodeDetailCard.scss
@@ -18,6 +18,11 @@
     text-transform: capitalize;
 }
 
+.card-subtitle {
+    text-align: center;
+    color: $text-color-light-semi-transparent;
+}
+
 .node-info-text {
     text-align: left;
 }

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -1,5 +1,8 @@
 @import "bootstrap";
 
+$text-color-light                 : black;
+$text-color-light-semi-transparent: rgba(0, 0, 0, 0.75);
+
 $navbar-top-height   : 3rem;
 $navbar-bottom-height: 3rem;
 
@@ -16,8 +19,7 @@ $graph_node_fill_pod: #3f33ff;
 // Services
 $graph_node_fill_service: #68686f;
 
-$node-class-fill-map: (
-    "alert": #cc241d,
+$node-class-fill-map: ("alert": #cc241d,
     "cluster": #3c3836,
     "config_map": #7c6f64,
     "daemon_set": #d65c0d,


### PR DESCRIPTION
The Node Detail Card displays information such as node coordinates and other irrelevant information. This PR changes this behavior so only `properties` are displayed (without `name` field). `name` field is displayed as a subtitle below `kind`. 

Here's how it looks:
![orca-ui-card-details](https://user-images.githubusercontent.com/46937539/87426397-6456a400-c5df-11ea-84a1-9e55094d83ad.png)

Hopefully `properties` will be extended with more information in near future.
