### PR TITLE
Add node icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": false,
   "license": "Apache-2.0",
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.14.0",
     "axios": "^0.19.2",
     "bootstrap": "^4.4.1",
     "d3": "^5.16.0",
-    "font-awesome": "^4.7.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0",

--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -63,7 +63,7 @@ export class DateTimePicker extends React.Component {
         </div>
         <div className="date-picker ml-auto">
           <span onClick={this.handleRefresh} className="refresh">
-            <i className="fa fa-refresh fa-lg" />
+            <i className="fas fa-sync-alt fa-lg" />
           </span>
           <DatePicker
             selected={this.state.date}

--- a/src/components/Graph.scss
+++ b/src/components/Graph.scss
@@ -7,32 +7,50 @@ svg.graph {
     z-index : 5;
 }
 
-g.link {
-    stroke: $graph_link_stroke_default;
-}
-
-g.graph-node {
-    fill        : $graph_node_fill_default;
-    stroke      : $graph_node_stroke_default;
-    stroke-width: 2;
+line.link {
+    stroke      : $graph_link_stroke_default;
+    stroke-width: 1;
 }
 
 @each $node-class,
 $node-fill in $node-class-fill-map {
     circle.#{$node-class} {
-        fill  : $node-fill;
-        stroke: darken($node-fill, 30%);
+        fill        : $node-fill;
+        stroke      : lighten($node-fill, 30%);
+        stroke-width: 1;
+    }
+
+    text.node-icon.#{$node-class} {
+        cursor: pointer;
+        stroke: lighten($node-fill, 50%);
+        fill  : darken($node-fill, 10%);
     }
 }
 
-circle.graph-node.clicked {
+text.node-icon.alert {
+    animation: blink 0.8s infinite;
+}
+
+g.node-group.clicked {
     filter: brightness(130%);
 }
 
 .stats {
-    float: right;
+    float       : right;
     margin-right: 1rem;
-    margin-top: 1rem;
-    z-index: 1030;
-    position  : relative;
+    margin-top  : 1rem;
+    z-index     : 1030;
+    position    : relative;
+}
+
+@keyframes blink {
+
+    100%,
+    0% {
+        fill: #500;
+    }
+
+    60% {
+        fill: #f00;
+    }
 }

--- a/src/components/IconMap.js
+++ b/src/components/IconMap.js
@@ -1,0 +1,22 @@
+export const IconMap = {
+  'alert': '\uf071',
+  'cluster': '\uf0c2',
+  'config_map': '\uf085',
+  'daemon_set': '\uf7d9',
+  'deployment': '\uf468',
+  'endpoints': '\uf7c0',
+  'ingress': '\uf0e8',
+  'node': '\uf233',
+  'persistent_volume': '\uf0a0',
+  'persistent_volume_claim': '\uf0a0',
+  'pod': '\uf1b2',
+  'replica_set': '\uf1b3',
+  //   'secret': '\uf54b',
+  'secret': '\uf6fa',
+  'service': '\uf562',
+  'stateful_set': '\uf247',
+  'storage_class': '\uf494'
+};
+
+//https://fontawesome.com/icons/project-diagram?style=solid
+//https://fontawesome.com/icons/network-wired?style=solid

--- a/src/components/_variables.scss
+++ b/src/components/_variables.scss
@@ -20,7 +20,7 @@ $graph_node_fill_pod: #3f33ff;
 $graph_node_fill_service: #68686f;
 
 $node-class-fill-map: ("alert": #cc241d,
-    "cluster": #3c3836,
+    "cluster": #326de6,
     "config_map": #7c6f64,
     "daemon_set": #d65c0d,
     "deployment": #458588,

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { Home, Navbar, Graph } from './components';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './assets/ui.css';
-import 'font-awesome/css/font-awesome.min.css';
+import '@fortawesome/fontawesome-free/css/all.min.css';
 
 const router = (
   <div className="wrapper">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,6 +1276,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@fortawesome/fontawesome-free@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
+  integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -5289,11 +5294,6 @@ follow-redirects@^1.0.0:
   integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
   dependencies:
     debug "^3.2.6"
-
-font-awesome@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
-  integrity sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
This PR introduces node icons:

- [x] each node has icon based on its kind
- [x] alert nodes have blinking icons so they stand out from the rest
- [x] we now use more recent version of Font Awesome (4.7.0 -> 5.14.0)

Now  #5 should finally be closable.

The impact on graph display performance should not be too noticeable.

Screen captures:
![orca-ui-icons-all](https://user-images.githubusercontent.com/46937539/89452416-e741c900-d75d-11ea-9452-9bb49b780909.PNG)
![only a couple](https://user-images.githubusercontent.com/46937539/89452420-e90b8c80-d75d-11ea-88f9-e9adf4bff075.PNG)
