### PR TITLE
Customize alerts table

### DIFF
--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -23,10 +23,25 @@ export class Alerts extends React.Component {
   loadData() {
     axios.get(process.env.REACT_APP_BACKEND_HOST + '/v1/alerts')
       .then((response) => {
-        const alerts = response.data.alerts.map(alert => {
+        var alerts = response.data.alerts.map(alert => {
           alert.updated_at = new Date(1000 * alert.updated_at);
           return alert;
         });
+
+        alerts = alerts.reduce((res, cur, index, array) => {
+          let cur1, cur2, cur3, cur4, cur5;
+          cur1 = Object.assign({}, cur);
+          cur2 = Object.assign({}, cur);
+          cur3 = Object.assign({}, cur);
+          cur4 = Object.assign({}, cur);
+          cur5 = Object.assign({}, cur);
+          cur1.id = cur.id + `1`
+          cur2.id = cur.id + `2`
+          cur3.id = cur.id + `3`
+          cur4.id = cur.id + `4`
+          cur5.id = cur.id + `5`
+          return res.concat([cur, cur1, cur2, cur3, cur4, cur5]);
+        }, []) 
 
         this.setState({
           alerts: alerts,
@@ -55,8 +70,14 @@ export class Alerts extends React.Component {
     }
 
     return (
-      <span className={`badge ${badgeStyle}`}> {cell} </span>
+      <span className={`badge ${badgeStyle}`}> {cell.toUpperCase()} </span>
     );
+  }
+
+  originFormatter(cell) {
+    return (
+      <span> {cell.charAt(0).toUpperCase() + cell.slice(1)} </span>
+    )
   }
 
   severitySortFunc(a, b, order, dataFiled) {
@@ -80,35 +101,6 @@ export class Alerts extends React.Component {
   }
 
   render() {
-    const pageButtonRenderer = ({
-      page,
-      active,
-      disable,
-      onPageChange
-    }) => {
-      const handleClick = (e) => {
-        e.preventDefault();
-        onPageChange(page);
-      };
-      const activeStyle = {};
-      if(active) {
-        activeStyle.backgroundColor = '#6c757d';
-        activeStyle.color = 'white';
-      } else {
-        activeStyle.color = '#6c757d';
-      }
-
-      return (
-        <li className="page-item">
-          <a className="page-link" href="#" onClick={handleClick} style={activeStyle}>{page}</a>
-        </li>
-      );
-    };
-
-    const paginationOptions = {
-      pageButtonRenderer
-    };
-
     const columns = [{
       dataField: 'severity',
       text: 'Severity',
@@ -127,6 +119,7 @@ export class Alerts extends React.Component {
     }, {
       dataField: 'origin',
       text: 'Origin',
+      formatter: this.originFormatter,
       sort: true,
       filter: selectFilter({
         options: this.getOptions('origin')
@@ -156,7 +149,7 @@ export class Alerts extends React.Component {
           </span>
           : <div className="alertTable" style={{hidden: this.state.loading}}>
             <BootstrapTable keyField='id' data={this.state.alerts} columns={columns} classes="table-dark" bootstrap4 striped hover
-              defaultSorted={defaultSort} pagination={paginationFactory(paginationOptions)} filter={filterFactory()}/>
+              defaultSorted={defaultSort} pagination={paginationFactory()} filter={filterFactory()}/>
           </div>
         }
       </div>

--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -134,7 +134,7 @@ export class Alerts extends React.Component {
           </span>
           : <div className="alertTable" style={{hidden: this.state.loading}}>
             <BootstrapTable keyField='id' data={this.state.alerts} columns={columns} classes="table-dark" bootstrap4 striped hover
-              defaultSorted={defaultSort} pagination={paginationFactory()} filter={filterFactory()}/>
+              defaultSorted={defaultSort} pagination={paginationFactory()} filter={filterFactory()} bordered={false}/>
           </div>
         }
       </div>

--- a/src/components/Alerts.js
+++ b/src/components/Alerts.js
@@ -23,25 +23,10 @@ export class Alerts extends React.Component {
   loadData() {
     axios.get(process.env.REACT_APP_BACKEND_HOST + '/v1/alerts')
       .then((response) => {
-        var alerts = response.data.alerts.map(alert => {
+        const alerts = response.data.alerts.map(alert => {
           alert.updated_at = new Date(1000 * alert.updated_at);
           return alert;
         });
-
-        alerts = alerts.reduce((res, cur, index, array) => {
-          let cur1, cur2, cur3, cur4, cur5;
-          cur1 = Object.assign({}, cur);
-          cur2 = Object.assign({}, cur);
-          cur3 = Object.assign({}, cur);
-          cur4 = Object.assign({}, cur);
-          cur5 = Object.assign({}, cur);
-          cur1.id = cur.id + `1`
-          cur2.id = cur.id + `2`
-          cur3.id = cur.id + `3`
-          cur4.id = cur.id + `4`
-          cur5.id = cur.id + `5`
-          return res.concat([cur, cur1, cur2, cur3, cur4, cur5]);
-        }, []) 
 
         this.setState({
           alerts: alerts,

--- a/src/components/Alerts.scss
+++ b/src/components/Alerts.scss
@@ -1,11 +1,58 @@
 @import "_variables.scss";
 
 .alertTable {
-    width: 1400px;
+    width: 80%;
     margin: 0 auto;
     margin-top: 15px;
 }
 
 .react-bootstrap-table table { 
     table-layout: auto !important; 
+}
+
+.table-dark {
+    background-color: $background-color-primary !important;
+}
+
+.page-item {
+    .page-link {
+        background-color: $background-color-primary !important;
+        border-color: $foreground-color-secondary !important;
+        color: $foreground-color-secondary !important;
+    }
+}
+
+.page-item.active {
+    .page-link {
+        color: $foreground-color-primary !important; 
+    }
+}
+
+#pageDropDown {
+    background-color: $background-color-primary !important;
+    border-color: $foreground-color-secondary !important;
+    color: $foreground-color-primary !important;
+}
+
+.dropdown-menu {
+    background-color: $background-color-primary !important;
+    border-color: $foreground-color-secondary !important;
+}
+
+.dropdown-item {
+    color: $foreground-color-primary !important;
+}
+
+.dropdown-item:hover {
+    color: $background-color-primary !important;
+}
+
+.form-control {
+    background-color: $background-color-primary !important;
+    border-color: $foreground-color-secondary !important;
+    color: $foreground-color-secondary !important;
+
+    option {
+        color: $foreground-color-secondary !important;
+    }
 }

--- a/src/components/Alerts.scss
+++ b/src/components/Alerts.scss
@@ -70,10 +70,6 @@
         color: $foreground-color-secondary !important;
         font-style: normal !important;
     }
-
-    option:hover {
-        box-shadow: 0 0 10px 10px #e1358f inset;
-    }
 }
 
 // Placeholders

--- a/src/components/Alerts.scss
+++ b/src/components/Alerts.scss
@@ -1,9 +1,19 @@
 @import "_variables.scss";
 
 .alertTable {
-    width: 80%;
+    width: 90%;
     margin: 0 auto;
-    margin-top: 15px;
+    margin-top: 50px;
+
+    thead {
+        th {
+            background-color: #343a40;
+
+            label {
+                margin-top: 8px;
+            }
+        }
+    }
 }
 
 .react-bootstrap-table table { 
@@ -17,26 +27,28 @@
 .page-item {
     .page-link {
         background-color: $background-color-primary !important;
-        border-color: $foreground-color-secondary !important;
+        border-color: #222526 !important;
         color: $foreground-color-secondary !important;
+        box-shadow: none !important;
     }
 }
 
 .page-item.active {
     .page-link {
-        color: $foreground-color-primary !important; 
+        color: $foreground-color-primary !important;
     }
 }
 
 #pageDropDown {
     background-color: $background-color-primary !important;
-    border-color: $foreground-color-secondary !important;
+    border-color: #222526 !important;
     color: $foreground-color-primary !important;
+    box-shadow: none !important;
 }
 
 .dropdown-menu {
     background-color: $background-color-primary !important;
-    border-color: $foreground-color-secondary !important;
+    border-color: #222526 !important;
 }
 
 .dropdown-item {
@@ -51,8 +63,36 @@
     background-color: $background-color-primary !important;
     border-color: $foreground-color-secondary !important;
     color: $foreground-color-secondary !important;
+    font-style: normal !important;
+    box-shadow: none !important;
 
     option {
         color: $foreground-color-secondary !important;
+        font-style: normal !important;
     }
+
+    option:hover {
+        box-shadow: 0 0 10px 10px #e1358f inset;
+    }
+}
+
+// Placeholders
+::-webkit-input-placeholder {
+    font-style: normal !important;
+    color: $foreground-color-secondary !important;
+}
+
+:-moz-placeholder {
+    font-style: normal !important;
+    color: $foreground-color-secondary !important;
+}
+
+::-moz-placeholder {
+    font-style: normal !important;
+    color: $foreground-color-secondary !important;
+}
+
+:-ms-input-placeholder {  
+    font-style: normal !important;
+    color: $foreground-color-secondary !important;
 }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,3 @@
-export { Home } from './Home';
 export { NavbarComponent as Navbar } from './Navbar';
 export { Graph } from './Graph';
 export { Alerts } from './Alerts';


### PR DESCRIPTION
This PR resolves #72 by adding a stylization to alerts table. Width of the table is dynamic relative to a user browser width. There were also minor fixes with using uppercase or capital letter in some field in the table. I temporary extended a payload for a better visualization (e.g. pager). 

![Alert_table](https://user-images.githubusercontent.com/37223468/90629576-e873fb00-e21f-11ea-8008-7a3bcf2af91a.png)


There is still some unresolved issues, like hovering color in select menu or color of calendar icon, but so for I didn't find an easy solution so far. We can try to use this version, collect some issues and provide resolving it in another PR.