### PR TITLE
Cluster, node, pod and alert as default type

### DIFF
--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -79,6 +79,7 @@ export class DateTimePicker extends React.Component {
             placeholder="Select Objects.."
             onChange={(e) => this.props.handleKindChange(e)}
             isMulti
+            defaultValue = {this.props.defaultKinds}
             theme={theme => ({
               ...theme,
               colors: {

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -22,7 +22,7 @@ export class Graph extends React.Component {
       namespaceOptions: [],
       objectKindOptions: [],
       namespace: null,
-      kinds: null,
+      kinds: ['cluster', 'node', 'pod', 'alert'],
       data: null,
       svg: null,
       g: null,
@@ -384,7 +384,12 @@ export class Graph extends React.Component {
         <NodeDetailCard ref={this.nodeDetailCard} />
         <DateTimePicker onSelect={this.onDateTimeSelect} namespaceOptions={this.state.namespaceOptions}
           objectKindOptions={this.state.objectKindOptions} handleNamespaceChange={this.handleNamespaceChange}
-          handleKindChange={this.handleKindChange} />
+          handleKindChange={this.handleKindChange} defaultKinds={this.state.kinds.map(kind => {
+            return {
+              label: kind,
+              value: kind
+            }
+          })}/>
       </div>
     );
   }

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -384,12 +384,12 @@ export class Graph extends React.Component {
         <NodeDetailCard ref={this.nodeDetailCard} />
         <DateTimePicker onSelect={this.onDateTimeSelect} namespaceOptions={this.state.namespaceOptions}
           objectKindOptions={this.state.objectKindOptions} handleNamespaceChange={this.handleNamespaceChange}
-          handleKindChange={this.handleKindChange} defaultKinds={this.state.kinds.map(kind => {
+          handleKindChange={this.handleKindChange} defaultKinds={this.state.kinds ? this.state.kinds.map(kind => {
             return {
               label: kind,
               value: kind
             }
-          })}/>
+          }) : null}/>
       </div>
     );
   }


### PR DESCRIPTION
This PR limit default view to ``cluster``, ``node``, ``pod`` and ``alert`` objects.

![DefaultTypes](https://user-images.githubusercontent.com/37223468/91998340-631e3980-ed3b-11ea-9d71-e976be7f871c.png)
