### PR TITLE
Attribute transform large graph error

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -103,7 +103,8 @@ export class Graph extends React.Component {
           namespaceOptions: namespaceOptions,
           objectKindOptions: objectKindOptions,
           data: response.data
-        }, () => {
+        }, async () => {
+          if(!timestamp) setTimeout(this.graphLoad, 2000);
           this.generateGraph(response.data);
         });
       })
@@ -186,8 +187,6 @@ export class Graph extends React.Component {
       simulation: simulation,
       svg: svg,
       g: g
-    }, () => {
-      setTimeout(this.graphLoad, 2000);
     });
   }
 
@@ -212,6 +211,8 @@ export class Graph extends React.Component {
     const graphY = g.node().getBBox().y;
     const graphWidth = g.node().getBBox().width;
     const graphHeight = g.node().getBBox().height;
+
+    if(graphWidth === 0 || graphHeight === 0) return;
 
     const scale = 0.95 / Math.max(graphWidth / width, graphHeight / height);
 

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -103,7 +103,7 @@ export class Graph extends React.Component {
           namespaceOptions: namespaceOptions,
           objectKindOptions: objectKindOptions,
           data: response.data
-        }, async () => {
+        }, () => {
           if(!timestamp) setTimeout(this.graphLoad, 2000);
           this.generateGraph(response.data);
         });


### PR DESCRIPTION
This PR closes #91, by function order redefinition in first graph generating in orca-ui.

The problem was connected with ``scaleGraph()`` function, which we triggered 2 seconds after page load. Sometimes it occurred that there wasn't time enough to get response from backend server and apply it to graph definition. This PR makes, that timeout starts **after** getting a response.

Moreover if there is a situation that ``scaleGraph()`` function was triggered and no nodes were detected in the graph, transform operation isn't executed.
