### PR TITLE
Ui tweaks

### DIFF
--- a/src/components/DateTimePicker.js
+++ b/src/components/DateTimePicker.js
@@ -65,7 +65,7 @@ export class DateTimePicker extends React.Component {
             maxDate={new Date()}
           />
         </div>
-        <div className="selector-container">
+        <div className="selector-container" id="namespace-selector-container">
           <Select
             className='react-select-container'
             classNamePrefix="react-select"
@@ -76,7 +76,7 @@ export class DateTimePicker extends React.Component {
             isClearable
           />
         </div>
-        <div className="selector-container">
+        <div className="selector-container" id="object-selector-container">
           <Select
             className='react-select-container'
             classNamePrefix="react-select"

--- a/src/components/DateTimePicker.scss
+++ b/src/components/DateTimePicker.scss
@@ -9,7 +9,7 @@
 }
 
 .react-select__control {
-    width: 15rem;
+    min-width: 14rem;
     background-color: $foreground-color-secondary !important;
     border: 1px solid $background-color-primary !important;
     border-radius: 0 !important;
@@ -94,4 +94,13 @@ input.date-picker {
 
 input.date-picker:focus {
     @extend .react-select__control--is-focused;
+}
+
+#namespace-selector-container {
+    width: 14rem;
+}
+
+
+#object-selector-contaier {
+    width: 28rem;
 }

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -9,6 +9,18 @@ import { NodeDetailCard } from './NodeDetailCard';
 import { IconMap } from './IconMap';
 import './Graph.scss';
 
+function truncate(fullStr, strLen, separator='...') {
+  if (fullStr.length <= strLen) return fullStr;
+
+  const sepLen = separator.length,
+    charsToShow = strLen - sepLen,
+    frontChars = Math.ceil(charsToShow / 2),
+    backChars = Math.floor(charsToShow / 2);
+
+  return fullStr.substr(0, frontChars) +
+    separator +
+    fullStr.substr(fullStr.length - backChars);
+}
 
 export class Graph extends React.Component {
   constructor(props) {
@@ -41,6 +53,7 @@ export class Graph extends React.Component {
     this.nodeCircleRadius = 16;
     this.nodeIconFontSize = 16;
     this.nodeLabelFontSize = 16;
+    this.nodeLabelLength = 18;
     this.nodeDetailCard = React.createRef();
     this.scaleGraph = this.scaleGraph.bind(this);
     this.graphLoad = this.graphLoad.bind(this);
@@ -122,14 +135,16 @@ export class Graph extends React.Component {
     nodeGroup.selectAll('circle').attr('r', this.nodeCircleRadius * multiplier);
     nodeGroup.selectAll('.node-icon').attr('font-size', `${this.nodeIconFontSize * multiplier}px`);
     nodeGroup.selectAll('.node-label').attr('font-size', `${this.nodeLabelFontSize * multiplier}px`)
-      .attr('y', this.nodeCircleRadius * 2 * multiplier);
+      .attr('y', this.nodeCircleRadius * 2 * multiplier)
+      .text((d) => d.properties.name);
   }
 
   nodeMouseOut(nodeGroup) {
     nodeGroup.selectAll('circle').attr('r', this.nodeCircleRadius);
     nodeGroup.selectAll('.node-icon').attr('font-size', `${this.nodeIconFontSize}px`);
     nodeGroup.selectAll('.node-label').attr('font-size', `${this.nodeLabelFontSize}px`)
-      .attr('y', this.nodeCircleRadius * 2);
+      .attr('y', this.nodeCircleRadius * 2)
+      .text((d) => truncate(d.properties.name, this.nodeLabelLength));
   }
 
   nodeClick(nodeGroup, nodeData) {
@@ -317,7 +332,7 @@ export class Graph extends React.Component {
       .attr('dominant-baseline', 'middle')
       .attr('font-size', `${this.nodeLabelFontSize}px`)
       .attr('y', this.nodeCircleRadius * 2)
-      .text((d) => d.properties.name);
+      .text((d) => truncate(d.properties.name, this.nodeLabelLength));
 
     const link = this.state.link
       .data(links, d => [d.source, d.target])

--- a/src/components/InterfaceVisibilityControls.js
+++ b/src/components/InterfaceVisibilityControls.js
@@ -22,8 +22,7 @@ export class InterfaceVisibilityControls extends React.Component {
     return (
       <div className='interface-visibility-controls-container'>
         <div class="custom-control custom-switch">
-          <input type="checkbox" className="custom-control-input" id="customSwitch1" checked={this.props.showLabels} onChange={(e) => this.props.toggleNodeLabels(e)} />
-          <label class="custom-control-label" for="customSwitch1">show labels</label>
+          <input type="checkbox" checked={this.props.showLabels} onChange={(e) => this.props.toggleNodeLabels(e)} />
         </div>
       </div>
     );

--- a/src/components/InterfaceVisibilityControls.js
+++ b/src/components/InterfaceVisibilityControls.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import './InterfaceVisibilityControls.scss';
 
 export class InterfaceVisibilityControls extends React.Component {
   constructor(props) {
@@ -14,15 +15,18 @@ export class InterfaceVisibilityControls extends React.Component {
     });
   }
 
-  shouldComponentUpdate(nextProps){
+  shouldComponentUpdate(nextProps) {
     return this.state.showLabels !== nextProps.showLabels;
   }
 
   render() {
     return (
       <div className='interface-visibility-controls-container'>
-        <div class="custom-control custom-switch">
-          <input type="checkbox" checked={this.props.showLabels} onChange={(e) => this.props.toggleNodeLabels(e)} />
+        <div className="custom-control custom-switch custom-switch-sm">
+          <input className="custom-control-input" id="labels-toggle" type="checkbox" checked={this.props.showLabels} onChange={(e) => this.props.toggleNodeLabels(e)} />
+          <label className="custom-control-label" for="labels-toggle">
+            <span className="custom-control-text">labels</span>
+          </label>
         </div>
       </div>
     );

--- a/src/components/InterfaceVisibilityControls.scss
+++ b/src/components/InterfaceVisibilityControls.scss
@@ -1,9 +1,49 @@
 @import "_variables.scss";
 
-.interface-visibility-controls-containe {
-    @extend .navbar-element;
+.interface-visibility-controls-container {
+  @extend .navbar-element;
+  padding-top: 0.4rem;
 }
 
-.custom-control-label.text {
-    color: $foreground-color-primary;
+.custom-control-text {
+  color       : $foreground-color-secondary;
+}
+
+@mixin switch($res: 'sm') {
+  $index  : 1rem;
+  $mainVal: 1rem;
+
+  .custom-control-label {
+    padding-left  : 0;
+    padding-bottom: #{$mainVal};
+  }
+
+  .custom-control-label::before {
+    height       : $mainVal;
+    width        : calc(#{$index} + 0.75rem);
+    border-radius: $mainVal * 2;
+    background-color: $background-color-primary;
+  }
+
+  .custom-control-label::after {
+    width        : calc(#{$mainVal} - 4px);
+    height       : calc(#{$mainVal} - 4px);
+    border-radius: calc(#{$index} - (#{$mainVal} / 2));
+    border-color: $foreground-color-secondary;
+    background-color: $foreground-color-secondary;
+  }
+
+  .custom-control-input:checked ~ .custom-control-label::before {
+    background-color: $background-color-secondary;
+    border-color: $accent-color-orange;
+  }
+
+  .custom-control-input:checked~.custom-control-label::after {
+    transform: translateX(calc(#{$mainVal} - 0.25rem));
+    background-color: $accent-color-yellow;
+  }
+}
+
+.custom-switch.custom-switch-sm {
+  @include switch();
 }


### PR DESCRIPTION
This PR introduces small UI tweaks:

* show labels switch now looks more appropriate

* long labels are truncated in the middle and are displayed fully on mouse hover as shown below

![label truncated](https://user-images.githubusercontent.com/46937539/94672975-54b14680-0316-11eb-9671-ca76eb62177f.PNG)

* object type selector length now matches its contents

![default](https://user-images.githubusercontent.com/46937539/94673006-5da21800-0316-11eb-9307-92caa002f681.PNG)
![empty](https://user-images.githubusercontent.com/46937539/94672997-5c70eb00-0316-11eb-99fe-1b37319904e7.PNG)
![multiple](https://user-images.githubusercontent.com/46937539/94673003-5d098180-0316-11eb-8719-383faa3ee16e.PNG)

This PR hopefully closes #103, #100 
