### PR TITLE
Configurable port for Orca UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ENV REACT_APP_BACKEND_HOST /api
 RUN yarn build
 
 FROM nginx:1.19.0-alpine
+
+ENV LISTEN_PORT=8080
+
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY nginx.conf.tpl /etc/nginx/nginx.conf.tpl
 
-CMD ["/bin/sh", "-c", "envsubst '${BACKEND_URL}' < /etc/nginx/nginx.conf.tpl > /etc/nginx/nginx.conf && exec nginx"]
+CMD ["/bin/sh", "-c", "envsubst '${LISTEN_PORT} ${BACKEND_URL}' < /etc/nginx/nginx.conf.tpl > /etc/nginx/nginx.conf && exec nginx"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ Run Docker container (specify correct IP and port of API container):
 docker run -it \
     --name orca-ui \
     -e "BACKEND_URL=http://172.17.0.2:5000" \
-    -p 80:80 \
+    -p 80:8080 \
+    openrca/orca-ui
+```
+
+To specify listen port `LISTEN_PORT` environment variable can be used:
+
+```sh
+docker run -it \
+    --name orca-ui \
+    --network=host \
+    -e "LISTEN_PORT=8555" \
+    -e "BACKEND_URL=http://127.0.0.1:5000" \
     openrca/orca-ui
 ```
 

--- a/nginx.conf.tpl
+++ b/nginx.conf.tpl
@@ -11,7 +11,7 @@ http {
     server {
         access_log /dev/stdout;
 
-        listen 80;
+        listen ${LISTEN_PORT};
 
         root  /usr/share/nginx/html;
         include /etc/nginx/mime.types;

--- a/utils/docker-compose.yaml
+++ b/utils/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   orca-proxy:
     build: ./orca_proxy
     ports:
-      - "80:80"
+      - "8080:8080"
 
   orca-ui:
     build:

--- a/utils/orca_proxy/nginx.conf
+++ b/utils/orca_proxy/nginx.conf
@@ -9,7 +9,7 @@ http {
     access_log /dev/stdout;
 
     server {
-        listen 80;
+        listen 8080;
 
         location / {
             proxy_pass http://orca-ui:3000/;


### PR DESCRIPTION
The default port has been changed from 80 to 8080 to avoid requirement for elevated privileges in some cases.

The port is now configurable via environment variable `LISTEN_PORT`. The `README.md` was updated accordingly.

Example:

``` sh
docker run -it --rm\
    --name orca-ui \
    --network=host \
    -e "LISTEN_PORT=8555" \
    -e "BACKEND_URL=http://127.0.0.1:5000" \
    openrca/orca-ui
```

This PR should close #108 