### PR TITLE
Optimize build time of UI images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:12 as builder
 WORKDIR /app
-COPY . ./
-RUN yarn
+COPY package.json yarn.lock ./
+RUN yarn --production --non-interactive
 ENV REACT_APP_BACKEND_HOST /api
+COPY . ./
 RUN yarn build
 
 FROM nginx:1.19.0-alpine

--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -2,9 +2,11 @@ FROM node:12
 
 WORKDIR /app
 
-COPY . ./
+COPY package.json yarn.lock ./
 
-RUN yarn
+RUN yarn --non-interactive
+
+COPY . ./
 
 EXPOSE 3000
 


### PR DESCRIPTION
Time of subsequent builds has been reduced by 50% for production `Dockerfile` and even more for development one as shown in table below.

`Dockerfile` | first build | second build (after source code change)
--- | --- | ---
production |   113.78 | 63.88
development |  74.26 |  9.00

Without proposed changes second build would take around the same as the first one. 
This should close #115 