### PR TITLE
Remove old circle and text elements

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -354,6 +354,13 @@ export class Graph extends React.Component {
         .attr('id', d => `node-group-${d.id}`))
       .call(this.drag(this.state.simulation));
 
+    //Removing old
+    const circles = nodeGroup.selectAll('circle');
+    circles.remove();
+
+    const text = nodeGroup.selectAll('text');
+    text.remove();
+
     const nodeCircle = nodeGroup.append('circle')
       .attr('id', d => `graph-node-${d.id}`)
       .attr('class', d => { return faultNodes.includes(d.id) ? `graph-node ${d.kind} fault` : `graph-node ${d.kind}`})


### PR DESCRIPTION
This PR remove old circles and text (icon too!) elements remaining after graph reloading. This PR will solve #117 and optimize simulation.