### PR TITLE
Detail card modification

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-bootstrap-table2-paginator": "^2.1.2",
     "react-datepicker": "^3.0.0",
     "react-dom": "^16.13.1",
+    "react-json-viewer": "^2.1.0",
     "react-loader-spinner": "^3.1.14",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-bootstrap-table2-paginator": "^2.1.2",
     "react-datepicker": "^3.0.0",
     "react-dom": "^16.13.1",
-    "react-json-viewer": "^2.1.0",
+    "react-json-view": "^1.19.1",
     "react-loader-spinner": "^3.1.14",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -452,16 +452,8 @@ export class Graph extends React.Component {
       return stat;
     }, stat);
 
-    const statList = [];
-    Object.keys(stat).forEach(key => {
-      statList.push({
-        type: key,
-        count: stat[key]
-      });
-    });
-
     this.setState({
-      stat: statList
+      stat: stat
     });
   }
 
@@ -470,7 +462,7 @@ export class Graph extends React.Component {
     this.nodeDetailCard.current.updateNodeData({
       kind: 'Statistics',
       properties: this.state.stat
-    }, true);
+    });
     this.nodeDetailCard.current.show();
   }
 

--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import BootstrapTable from 'react-bootstrap-table-next';
 import ReactJson from 'react-json-view';
 
 import './NodeDetailCard.scss';
@@ -40,32 +39,6 @@ export class NodeDetailCard extends React.Component {
   }
 
   render() {
-    const columns = [{
-      dataField: 'attribute',
-      text: 'attribute',
-      headerAttrs: {
-        hidden: true
-      }
-    }, {
-      dataField: 'value',
-      text: 'value',
-      headerAttrs: {
-        hidden: true
-      }
-    }];
-    const columnsStats = [{
-      dataField: 'type',
-      text: 'type',
-      headerAttrs: {
-        hidden: true
-      }
-    }, {
-      dataField: 'count',
-      text: 'count',
-      headerAttrs: {
-        hidden: true
-      }
-    }];
     return (
       <div className={`card node-info-card ${this.state.hidden ? 'hidden' : ''} pt-0`}>
         <button type="button" className="close mt-1 mr-2 mb-0" aria-label="Close" onClick={this.hide}>

--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -48,7 +48,7 @@ export class NodeDetailCard extends React.Component {
           <h4 className="card-title">{this.state.nodeData.properties.name}</h4>
           <h5 className="card-subtitle">{this.state.nodeData.kind.replace('_', ' ')}</h5>
           <div className="card-text node-info-text">
-            <ReactJson src={this.state.displayProperties} name={null} collapsed={2} />
+            <ReactJson src={this.state.displayProperties} name={null} collapsed={2} displayDataTypes={false}/>
           </div>
         </div>
       </div>

--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import BootstrapTable from 'react-bootstrap-table-next';
+import JSONViewer from 'react-json-viewer';
 
 import './NodeDetailCard.scss';
 import './Table.scss';
@@ -25,14 +26,17 @@ export class NodeDetailCard extends React.Component {
   updateNodeData(nodeData, statistics = false) {
     let displayProperties = nodeData.properties;
     if(!statistics) {
-      displayProperties = Object.keys(nodeData.properties).reduce((object, key) => {
+      displayProperties = Object.keys(nodeData.properties).reduce((list, key) => {
+        const object = {}
         if(key !== 'name'){
           object['attribute'] = key;
           object['value'] = nodeData.properties[key];
+          list.push(object)
         }
-  
-        return object;
-      }, {});
+        
+
+        return list;
+      }, []);
       displayProperties = [displayProperties];
     } else {
       displayProperties = nodeData.properties.map((object) => {
@@ -93,8 +97,7 @@ export class NodeDetailCard extends React.Component {
           <h4 className="card-title">{this.state.nodeData.properties.name}</h4>
           <h5 className="card-subtitle">{this.state.nodeData.kind.replace('_', ' ')}</h5>
           <div className="card-text node-info-text">
-            <BootstrapTable keyField='id' data={this.state.displayProperties} columns={this.state.statistics ? columnsStats : columns} 
-              classes="table-dark" bootstrap4 striped hover/>
+            <JSONViewer json={this.state.displayProperties} />
           </div>
         </div>
       </div>

--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import BootstrapTable from 'react-bootstrap-table-next';
-import JSONViewer from 'react-json-viewer';
+import ReactJson from 'react-json-view';
 
 import './NodeDetailCard.scss';
 import './Table.scss';
@@ -25,8 +25,9 @@ export class NodeDetailCard extends React.Component {
 
   updateNodeData(nodeData, statistics = false) {
     let displayProperties = nodeData.properties;
+    console.log(displayProperties)
     if(!statistics) {
-      displayProperties = Object.keys(nodeData.properties).reduce((list, key) => {
+      /*displayProperties = Object.keys(nodeData.properties).reduce((list, key) => {
         const object = {}
         if(key !== 'name'){
           object['attribute'] = key;
@@ -37,13 +38,13 @@ export class NodeDetailCard extends React.Component {
 
         return list;
       }, []);
-      displayProperties = [displayProperties];
+      displayProperties = [displayProperties];*/
     } else {
-      displayProperties = nodeData.properties.map((object) => {
+      /*displayProperties = nodeData.properties.map((object) => {
         object['attribute'] = object.type;
         object['value'] = object.count;
         return object;
-      });
+      });*/
     }
     
     this.setState({ 
@@ -97,7 +98,7 @@ export class NodeDetailCard extends React.Component {
           <h4 className="card-title">{this.state.nodeData.properties.name}</h4>
           <h5 className="card-subtitle">{this.state.nodeData.kind.replace('_', ' ')}</h5>
           <div className="card-text node-info-text">
-            <JSONViewer json={this.state.displayProperties} />
+            <ReactJson src={this.state.displayProperties} name={null} collapsed={2} collapsedStringAfterLenght={20}/>
           </div>
         </div>
       </div>

--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -16,41 +16,18 @@ export class NodeDetailCard extends React.Component {
         }
       },
       hidden: true,
-      displayProperties: [],
-      statistics: false
+      displayProperties: []
     };
 
     this.hide = this.hide.bind(this);
   }
 
-  updateNodeData(nodeData, statistics = false) {
+  updateNodeData(nodeData) {
     let displayProperties = nodeData.properties;
-    console.log(displayProperties)
-    if(!statistics) {
-      /*displayProperties = Object.keys(nodeData.properties).reduce((list, key) => {
-        const object = {}
-        if(key !== 'name'){
-          object['attribute'] = key;
-          object['value'] = nodeData.properties[key];
-          list.push(object)
-        }
-        
 
-        return list;
-      }, []);
-      displayProperties = [displayProperties];*/
-    } else {
-      /*displayProperties = nodeData.properties.map((object) => {
-        object['attribute'] = object.type;
-        object['value'] = object.count;
-        return object;
-      });*/
-    }
-    
     this.setState({ 
       nodeData: nodeData,
-      displayProperties: displayProperties,
-      statistics: statistics
+      displayProperties: displayProperties
     });
   }
 
@@ -98,7 +75,7 @@ export class NodeDetailCard extends React.Component {
           <h4 className="card-title">{this.state.nodeData.properties.name}</h4>
           <h5 className="card-subtitle">{this.state.nodeData.kind.replace('_', ' ')}</h5>
           <div className="card-text node-info-text">
-            <ReactJson src={this.state.displayProperties} name={null} collapsed={2} collapsedStringAfterLenght={20}/>
+            <ReactJson src={this.state.displayProperties} name={null} collapsed={2} />
           </div>
         </div>
       </div>

--- a/src/components/NodeDetailCard.scss
+++ b/src/components/NodeDetailCard.scss
@@ -14,7 +14,7 @@
     color: $text-color-light;
 }
 
-.react-bootstrap-table {
+.react-json-view {
     max-height: 70vh;
     overflow-y: auto;
     overflow-x: auto;

--- a/src/components/NodeDetailCard.scss
+++ b/src/components/NodeDetailCard.scss
@@ -15,9 +15,14 @@
 }
 
 .react-json-view {
+    margin-top: 10px;
     max-height: 70vh;
     overflow-y: auto;
     overflow-x: auto;
+}
+
+.object-key {
+    font-weight: 900;
 }
 
 .card.node-info-card:hover {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,7 +2275,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.6:
+asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -2565,6 +2565,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base16@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
+  integrity sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=
 
 base64-js@^1.0.2:
   version "1.3.0"
@@ -3432,6 +3437,11 @@ core-js-pure@^3.0.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
 core-js@^2.4.0:
   version "2.6.5"
@@ -4533,6 +4543,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.11:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -5130,6 +5147,26 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbemitter@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fbemitter/-/fbemitter-2.1.1.tgz#523e14fdaf5248805bb02f62efc33be703f51865"
+  integrity sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=
+  dependencies:
+    fbjs "^0.8.4"
+
+fbjs@^0.8.0, fbjs@^0.8.4:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -5280,6 +5317,14 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+flux@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/flux/-/flux-3.1.3.tgz#d23bed515a79a22d933ab53ab4ada19d05b2f08a"
+  integrity sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=
+  dependencies:
+    fbemitter "^2.0.0"
+    fbjs "^0.8.0"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -5963,6 +6008,13 @@ iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
@@ -6478,7 +6530,7 @@ is-root@2.1.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -6553,6 +6605,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -7373,6 +7433,16 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.curry@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+  integrity sha1-JI42By7ekGUB11lmIAqG2riyMXA=
+
+lodash.flow@^3.3.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
+  integrity sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -7941,6 +8011,14 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -9567,6 +9645,13 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 promise@^8.0.3:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -9674,6 +9759,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pure-color@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
+  integrity sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
@@ -9770,6 +9860,16 @@ react-app-polyfill@^1.0.6:
     raf "^3.4.1"
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
+
+react-base16-styling@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-base16-styling/-/react-base16-styling-0.6.0.tgz#ef2156d66cf4139695c8a167886cb69ea660792c"
+  integrity sha1-7yFW1mz0E5aVyKFniGy2nqZgeSw=
+  dependencies:
+    base16 "^1.0.0"
+    lodash.curry "^4.0.1"
+    lodash.flow "^3.3.0"
+    pure-color "^1.2.0"
 
 react-bootstrap-table-next@^4.0.3:
   version "4.0.3"
@@ -9882,10 +9982,15 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
-react-json-viewer@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-json-viewer/-/react-json-viewer-2.1.0.tgz#42234f715d2af95a7993759b1bf7b3c8e7fbf854"
-  integrity sha512-9TeJ+zqmCLueLv/OJ5JFEl/0VQqJzhiRjsbVvc9YocUuhMebWGHJ0RLPERPwpUZnlfJvaaowpj/HcdNMmVaAQg==
+react-json-view@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/react-json-view/-/react-json-view-1.19.1.tgz#95d8e59e024f08a25e5dc8f076ae304eed97cf5c"
+  integrity sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==
+  dependencies:
+    flux "^3.1.3"
+    react-base16-styling "^0.6.0"
+    react-lifecycles-compat "^3.0.4"
+    react-textarea-autosize "^6.1.0"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -10034,6 +10139,13 @@ react-select@^3.1.0:
     prop-types "^15.6.0"
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
+
+react-textarea-autosize@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz#df91387f8a8f22020b77e3833c09829d706a09a5"
+  integrity sha512-F6bI1dgib6fSvG8so1HuArPUv+iVEfPliuLWusLF+gAKz0FbB4jLrWUrTAeq1afnPT2c9toEZYUdz/y1uKMy4A==
+  dependencies:
+    prop-types "^15.6.0"
 
 react-transition-group@^4.0.0:
   version "4.3.0"
@@ -10573,7 +10685,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10768,7 +10880,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -11803,6 +11915,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+ua-parser-js@^0.7.18:
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
+  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
+
 uncontrollable@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.1.1.tgz#f67fed3ef93637126571809746323a9db815d556"
@@ -12212,6 +12329,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@>=0.10.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz#605a2cd0a7146e5db141e29d1c62ab84c0c4c868"
+  integrity sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==
 
 whatwg-fetch@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9882,6 +9882,11 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
+react-json-viewer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-json-viewer/-/react-json-viewer-2.1.0.tgz#42234f715d2af95a7993759b1bf7b3c8e7fbf854"
+  integrity sha512-9TeJ+zqmCLueLv/OJ5JFEl/0VQqJzhiRjsbVvc9YocUuhMebWGHJ0RLPERPwpUZnlfJvaaowpj/HcdNMmVaAQg==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
This PR introduce new Detail Card view. In this new approach we wanted to display nodes details using some collapsable JSON format, instead of table view, which was really unreadable for more complexes objects.

Details of a pod:
![DetailCard_modification1](https://user-images.githubusercontent.com/37223468/100228599-32f1cb80-2f23-11eb-8aa6-7132e8cedd38.png)

Statistics:
![DetailCard_modification2](https://user-images.githubusercontent.com/37223468/100228619-39804300-2f23-11eb-8421-38f15fc38f47.png)


As you can see, apart from clear, readable, flexible and easily to navigate view we provide a lot of useful features for operators, like:
 - number of items in an array/ objects
 - items type
 - copy to clipboard option

I decided to set the collapse parameter to 2nd degree of nesting in default view.