### PR TITLE
Remove classed func execution on empty data

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -399,7 +399,7 @@ export class Graph extends React.Component {
       nodeCircle: nodeCircle,
       nodeIcon: nodeIcon,
       nodeGroup: nodeGroup,
-      showLabels: !nodeLabel.classed('hidden'),
+      showLabels: nodeLabel._groups[0].length > 0 ? !nodeLabel.classed('hidden') : null,
       link: link
     }, () => {
       this.state.simulation.nodes(nodes);


### PR DESCRIPTION
This PR resolves bug described in #134 and #135. ``classed()`` func should not be executed on empty data.