### PR TITLE
Empty namespace

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -100,7 +100,9 @@ export class Graph extends React.Component {
     const param = timestamp ? `?time_point=${timestamp}` : '';
     axios.get(process.env.REACT_APP_BACKEND_HOST + '/v1/graph' + param)
       .then((response) => {
-        const namespaces = [...new Set(response.data.nodes.map(nodeGroup => nodeGroup.properties ? nodeGroup.properties.namespace : null))];
+        const namespaces = [...new Set(response.data.nodes.map(nodeGroup => {
+          return nodeGroup.properties && nodeGroup.properties.namespace? nodeGroup.properties.namespace : null
+        }))].filter(namespace => namespace != null);
         const namespaceOptions = namespaces.map(namespace => ({
           value: namespace,
           label: namespace

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -101,7 +101,7 @@ export class Graph extends React.Component {
     axios.get(process.env.REACT_APP_BACKEND_HOST + '/v1/graph' + param)
       .then((response) => {
         const namespaces = [...new Set(response.data.nodes.map(nodeGroup => {
-          return nodeGroup.properties && nodeGroup.properties.namespace? nodeGroup.properties.namespace : null
+          return nodeGroup.properties && nodeGroup.properties.namespace? nodeGroup.properties.namespace : null;
         }))].filter(namespace => namespace != null);
         const namespaceOptions = namespaces.map(namespace => ({
           value: namespace,


### PR DESCRIPTION
In some cases nodes object doesn't have namespace assigned. It happens in case of ``nodes``, ``clusters``, ``alerts`` etc. The previous behavior didn't included that fact in constructing namespaces list, and in that case the ``undefined`` namespace was pushed to the list. It occured as an empty namespace option in namespace selector described in #133. This PR resolves that issue by filtering undesirable values from namespace option list.