### PR TITLE
Add link labels in rca dashboard

### DIFF
--- a/src/components/Graph.scss
+++ b/src/components/Graph.scss
@@ -60,7 +60,9 @@ text.node-label {
     cursor: pointer;
 }
 
-
+text.link-label {
+    fill: $foreground-color-secondary;
+}
 
 g.node-group.clicked {
     filter: brightness(130%);

--- a/src/components/Graph.scss
+++ b/src/components/Graph.scss
@@ -62,6 +62,7 @@ text.node-label {
 
 text.link-label {
     fill: $foreground-color-secondary;
+    text-shadow: 2px 2px $background-color-primary;
 }
 
 g.node-group.clicked {

--- a/src/components/RCA.js
+++ b/src/components/RCA.js
@@ -231,6 +231,7 @@ export class RCA extends React.Component {
     const linkText = linkGroup.append("text")
       .attr("class", "link-label")
       .attr('font-size', `${this.linkLabelFontSize}px`)
+      .attr('text-anchor', 'middle')
       .text(d => d.properties.strength);
 
     nodeGroup

--- a/src/components/RCA.js
+++ b/src/components/RCA.js
@@ -30,6 +30,7 @@ export class RCA extends React.Component {
     this.nodeIconFontSize = 16;
     this.nodeLabelFontSize = 16;
     this.nodeLabelLength = 18;
+    this.linkLabelFontSize = 10;
   }
 
   componentDidMount() {
@@ -96,6 +97,9 @@ export class RCA extends React.Component {
     const link = g.append('g')
       .selectAll('line');
 
+    const linkGroup = g.append('g')
+      .selectAll('.link-group')
+
     const nodeGroup = g.append('g')
       .selectAll('.node-group');
 
@@ -110,6 +114,7 @@ export class RCA extends React.Component {
 
     this.setState({
       link: link,
+      linkGroup: linkGroup,
       nodeGroup: nodeGroup,
       nodeCircle: nodeCircle,
       nodeIcon: nodeIcon,
@@ -212,10 +217,21 @@ export class RCA extends React.Component {
       .attr('y', this.nodeCircleRadius * 2)
       .text((d) => truncate(d.properties.name, this.nodeLabelLength));
 
-    const link = this.state.link
+    const linkGroup = this.state.linkGroup
+      .data(links, d => [d.source, d.target])
+      .join(enter => enter.append('g')
+        .attr('class', 'link-group')
+        .attr('id', d => `link-group-${d.id}`))
+
+    const link = linkGroup.append("line")
       .data(links, d => [d.source, d.target])
       .join('line')
       .attr('class', d => {return d.fault ? 'link fault' : 'link';});
+
+    const linkText = linkGroup.append("text")
+      .attr("class", "link-label")
+      .attr('font-size', `${this.linkLabelFontSize}px`)
+      .text(d => d.properties.strength);
 
     nodeGroup
       .on('mouseover', d => this.nodeMouseOver(d3.select(`#node-group-${d.id}`), d))
@@ -227,7 +243,9 @@ export class RCA extends React.Component {
       nodeIcon: nodeIcon,
       nodeGroup: nodeGroup,
       showLabels: nodeLabel._groups[0].length > 0 ? !nodeLabel.classed('hidden') : null,
-      link: link
+      link: link,
+      linkText: linkText,
+      linkGroup: linkGroup
     }, () => {
       this.state.simulation.nodes(nodes);
       this.state.simulation.force('link').links(links);
@@ -241,6 +259,12 @@ export class RCA extends React.Component {
       .attr('y1', function (d) { return d.source.y; })
       .attr('x2', function (d) { return d.target.x; })
       .attr('y2', function (d) { return d.target.y; });
+
+    if(this.state.linkText) {
+      this.state.linkText
+        .attr('x', d => (d.source.x + d.target.x)/2)
+        .attr('y', d => (d.source.y + d.target.y)/2)
+    }
 
     this.state.nodeGroup
       .attr('transform', d => `translate(${d.x}, ${d.y})`);


### PR DESCRIPTION
This PR introduces link labels in RCA dashboards containing trajectory strength. Label orientation to be determined -> status WIP.

![LabelLink](https://user-images.githubusercontent.com/37223468/119662725-fcddc780-be31-11eb-98b7-325d10b8248f.png)
