### PR TITLE
Add node detail card in RCA graph

### DIFF
--- a/src/components/NodeDetailCard.js
+++ b/src/components/NodeDetailCard.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactJson from 'react-json-view';
-import * as d3 from 'd3';
 
 import './NodeDetailCard.scss';
 
@@ -16,7 +15,8 @@ export class NodeDetailCard extends React.Component {
       },
       hidden: true,
       displayProperties: [],
-      stat: {}
+      stat: {},
+      floatRight: false
     };
   }
 
@@ -25,7 +25,8 @@ export class NodeDetailCard extends React.Component {
       nodeData: this.props.nodeData,
       displayProperties: this.props.nodeData.properties,
       hidden: this.props.hidden,
-      stat: this.props.stat
+      stat: this.props.stat,
+      floatRight: this.props.floatRight
     });
   }
 
@@ -39,7 +40,7 @@ export class NodeDetailCard extends React.Component {
 
   render() {
     return (
-      <div className={`card node-info-card ${this.state.hidden ? 'hidden' : ''} pt-0`}>
+      <div className={`card node-info-card ${this.state.hidden ? 'hidden' : ''} pt-0 ${this.state.floatRight ? "right" : ''}`}>
         <button type="button" className="close mt-1 mr-2 mb-0" aria-label="Close" onClick={this.props.hideDetailCard}>
           <span aria-hidden="true">&times;</span>
         </button>

--- a/src/components/NodeDetailCard.scss
+++ b/src/components/NodeDetailCard.scss
@@ -14,6 +14,11 @@
     color: $text-color-light;
 }
 
+.card.node-info-card.right {
+    margin: 2rem 2rem 0 0;
+    float: right;
+}
+
 .react-json-view {
     margin-top: 10px;
     max-height: 70vh;

--- a/src/components/RCA.js
+++ b/src/components/RCA.js
@@ -9,6 +9,7 @@ import { IconMap } from './IconMap';
 import { truncate } from './Utils';
 import './Graph.scss';
 import { Selector } from './Selector';
+import { NodeDetailCard } from './NodeDetailCard';
 
 export class RCA extends React.Component {
   constructor(props){
@@ -21,13 +22,21 @@ export class RCA extends React.Component {
       //Same format as in /v1/graph endpoint
       nodeGroup: null,
       scale_const: 0.5,
-      selector_hidden: false
+      selector_hidden: false,
+      showDetailCard: false,
+      nodeData: {
+        kind: '',
+        properties: {
+          name: ''
+        }
+      },
     };
 
     this.zoom = d3.zoom();
 
     this.generateGraph = this.generateGraph.bind(this);
     this.handleTrajectoryChange = this.handleTrajectoryChange.bind(this);
+    this.hideDetailCard = this.hideDetailCard.bind(this);
     this.ticked = this.ticked.bind(this);
     this.nodeCircleRadius = 16;
     this.nodeIconFontSize = 16;
@@ -281,6 +290,10 @@ export class RCA extends React.Component {
       .attr('transform', d => `translate(${d.x}, ${d.y})`);
   }
 
+  hideDetailCard() {
+    this.setState({ showDetailCard: false });
+  }
+
   render() {
     return(
       <div>
@@ -289,6 +302,7 @@ export class RCA extends React.Component {
         </span>
         <div id="chart-area" />
         <Selector hidden={this.state.selector_hidden} options={this.state.rca} handleChange={this.handleTrajectoryChange} />
+        <NodeDetailCard hidden={!this.state.showDetailCard} nodeData={this.state.nodeData} hideDetailCard={this.hideDetailCard} floatRight={true}/>
       </div>
     );
   }


### PR DESCRIPTION
This PR introduces NodeDetailCard component in RCA dashboard.

![Detail_card_rca](https://user-images.githubusercontent.com/37223468/122197422-72b8da00-ce98-11eb-9a0c-e59d9f40e10b.png)
