### PR TITLE
Cast timestamp to integer

### DIFF
--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -38,7 +38,7 @@ export class Graph extends React.Component {
       g: null,
       loading: true,
       stat: null,
-      timestamp: new Date().getTime()/1000
+      timestamp: parseInt(new Date().getTime()/1000)
     };
 
     this.zoom = d3.zoom();


### PR DESCRIPTION
This PR resolves #181. There is added parsing to integer type of a timestamp value.